### PR TITLE
Fix GitLab url (for deep repository source link)

### DIFF
--- a/include/source/database.json
+++ b/include/source/database.json
@@ -11,7 +11,7 @@
   },
   {
     "name": "GitLab",
-    "url": "https://bitbucket.org/",
-    "link": "https://bitbucket.org/{user}/{project}/blob/{branch}/{filepath}"
+    "url": "https://gitlab.com/",
+    "link": "https://gitlab.com/{user}/{project}/blob/{branch}/{filepath}"
   }
 ]


### PR DESCRIPTION
Took me some time to figure out why files were 'deep linked' to _bitbucket_, although I had select "GitLab". Turns out it's a bug 😄.