### PR TITLE
add attribute for unsafe links and fix protocol typo

### DIFF
--- a/assets/sales/pricing.html
+++ b/assets/sales/pricing.html
@@ -93,8 +93,8 @@
           <tr>
             <th scope="row"></th>
             <td><div style="margin-top:14px;"><a id="communitydownload" href="https://searchcodeserver.com/searchcode-server-community.tar.gz" class="top20">Free Community Edition</a></div></td>
-            <td><a data-gumroad-single-product="true" target="_blank" class="gumroad-button" href="https://gum.co/spTnp">Buy now $99</a></td>
-            <td><a data-gumroad-single-product="true" target="_blank" class="gumroad-button" href="https://gum.co/XJVCH">Buy now $699</a></td>
+            <td><a data-gumroad-single-product="true" target="_blank" rel="noopener noreferrer" class="gumroad-button" href="https://gum.co/spTnp">Buy now $99</a></td>
+            <td><a data-gumroad-single-product="true" target="_blank" rel="noopener noreferrer" class="gumroad-button" href="https://gum.co/XJVCH">Buy now $699</a></td>
           </tr>
         </tbody>
       </table>

--- a/src/main/resources/spark/template/freemarker/admin_settings.ftl
+++ b/src/main/resources/spark/template/freemarker/admin_settings.ftl
@@ -43,7 +43,7 @@
                     <tr>
                         <td></td>
                         <td>Empty this field to reset. Should be in format similar to the below.
-                            This format can be created using <a target="_blank"
+                            This format can be created using <a target="_blank" rel="noopener noreferrer"
                                                                 href="http://www.dailycoding.com/Utils/Converter/ImageToBase64.aspx">Online
                                 Image to Base64 Converter</a>
                             but consider resizing the image to a height of 24 px first.

--- a/src/main/resources/spark/template/freemarker/documentation.ftl
+++ b/src/main/resources/spark/template/freemarker/documentation.ftl
@@ -254,7 +254,7 @@
             </p>
 
             <h3 id="estimatedcost">Estimated Cost</h3>
-            <p>The estimated cost for any file or project is created using the <a target="_blank"
+            <p>The estimated cost for any file or project is created using the <a target="_blank" rel="noopener noreferrer"
                                                                                   href="https://en.wikipedia.org/wiki/COCOMO">Basic
                     COCOMO</a>
                 algorithmic software cost estimation model. The cost reflected includes design, coding, testing,
@@ -957,7 +957,7 @@ String myHmac = HmacUtils.hmacSha512Hex(MYPRIVATEKEY, PARAMSTOHMAC);</textarea>
                 <#if isCommunity??>
                     <#if isCommunity == true>
                         You are using the community edition of searchcode server. As such you will be unable to change anything here. If you would like the ability to configure the settings page
-                        you can purchase a copy at <a href="hhttps://searchcodeserver.com/pricing.html">https://searchcodeserver.com/pricing.html</a>
+                        you can purchase a copy at <a href="https://searchcodeserver.com/pricing.html">https://searchcodeserver.com/pricing.html</a>
                     </#if>
                 </#if>
 


### PR DESCRIPTION
`target="_blank"` is vulnerable to clickjacking, and `rel="noopener noreferrer"` addresses this issue. You could just add `rel="noopener"`, though `noreferrer` is still useful for legacy browsers that don't support `noopener`.